### PR TITLE
DE36341 Add cache-busting query string to ifrau host url

### DIFF
--- a/google-drive-viewer.js
+++ b/google-drive-viewer.js
@@ -121,7 +121,7 @@ if( window.ifrauhost ) {
 	customElements.define(GoogleDriveViewerElement.is, GoogleDriveViewerElement);
 } else {
 	const ifrauImport = document.createElement( 'script' );
-	ifrauImport.src = 'https://s.brightspace.com/lib/ifrau/0.28.0/ifrau/host.js';
+	ifrauImport.src = `https://s.brightspace.com/lib/ifrau/0.28.0/ifrau/host.js?cacheBuster=${Date.now()}`;
 	ifrauImport.onload = function() {
 		customElements.define(GoogleDriveViewerElement.is, GoogleDriveViewerElement);
 	};


### PR DESCRIPTION
[Rally Defect](https://rally1.rallydev.com/#/289692574792/detail/defect/339505337664)

`host.js` is ~33kb large so this never caching it is not a huge impact.

This is to make sure safari doesn't block loading this file from cache because of CORS errors.